### PR TITLE
Making v-backup-user able to upload backup to FTP if FTP folder is no…

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -557,6 +557,9 @@ ftp_backup() {
         check_result "$E_PARSING" "$error"
     fi
 
+    if [ -z $BPATH ]; then
+        BPATH="/";
+    fi
 
     # Debug info
     echo -e "$(date "+%F %T") Remote: ftp://$HOST$BPATH/$user.$date.tar"


### PR DESCRIPTION
…t set

Before this fix v-backup-user was unable to upload backup to FTP if $BPATH (FTP folder) is not set