### PR TITLE
Cron format validation fix

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -737,7 +737,7 @@ is_cron_format_valid() {
             fi
         done
     fi
-    if [[ "$1" =~ ^[0-9]+$ ]] && [ "$1" -lt $limit ]; then
+    if [[ "$1" =~ ^[0-9]+$ ]] && [ "$1" -le $limit ]; then
         check_format='ok'
     fi
     if [ "$check_format" != 'ok' ]; then


### PR DESCRIPTION
-lt is 'lower than', so if you have wday=7 it will not be valid, which is wrong, because wday range is 0-7.
Changed to -le which means 'lower or equal'