### PR TITLE
Backup filename changed (#1289)

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -472,11 +472,12 @@ end_time=$(date '+%s')
 time_n_date=$(date +'%T %F')
 time=$(echo "$time_n_date" |cut -f 1 -d \ )
 date=$(echo "$time_n_date" |cut -f 2 -d \ )
+backup_new_date=$(date +"%Y-%m-%d_%H-%M-%S")
 
 # Defining local storage function
 local_backup(){
 
-    rm -f $BACKUP/$user.$date.tar
+    rm -f $BACKUP/$user.$backup_new_date.tar
 
     # Checking retention
     backup_list=$(ls -lrt $BACKUP/ |awk '{print $9}' |grep "^$user\." | grep ".tar")
@@ -506,11 +507,11 @@ local_backup(){
 
     # Creating final tarball
     cd $tmpdir
-    tar -cf $BACKUP/$user.$date.tar .
-    chmod 640 $BACKUP/$user.$date.tar
-    chown admin:$user $BACKUP/$user.$date.tar
+    tar -cf $BACKUP/$user.$backup_new_date.tar .
+    chmod 640 $BACKUP/$user.$backup_new_date.tar
+    chown admin:$user $BACKUP/$user.$backup_new_date.tar
     localbackup='yes'
-    echo -e "$(date "+%F %T") Local: $BACKUP/$user.$date.tar" |\
+    echo -e "$(date "+%F %T") Local: $BACKUP/$user.$backup_new_date.tar" |\
         tee -a $BACKUP/$user.log
 }
 
@@ -559,7 +560,7 @@ ftp_backup() {
     fi
 
     # Debug info
-    echo -e "$(date "+%F %T") Remote: ftp://$HOST$BPATH/$user.$date.tar"
+    echo -e "$(date "+%F %T") Remote: ftp://$HOST$BPATH/$user.$backup_new_date.tar"
 
     # Checking ftp connection
     fconn=$(ftpc)
@@ -616,20 +617,20 @@ ftp_backup() {
     if [ "$localbackup" = 'yes' ]; then
         cd $BACKUP
         if [ -z $BPATH ]; then
-            ftpc "put $user.$date.tar"
+            ftpc "put $user.$backup_new_date.tar"
          else
-            ftpc "cd $BPATH" "put $user.$date.tar"
+            ftpc "cd $BPATH" "put $user.$backup_new_date.tar"
         fi
     else
         cd $tmpdir
-        tar -cf $BACKUP/$user.$date.tar .
+        tar -cf $BACKUP/$user.$backup_new_date.tar .
         cd $BACKUP/
         if [ -z $BPATH ]; then
-            ftpc "put $user.$date.tar"
+            ftpc "put $user.$backup_new_date.tar"
         else
-            ftpc "cd $BPATH" "put $user.$date.tar"
+            ftpc "cd $BPATH" "put $user.$backup_new_date.tar"
         fi
-        rm -f $user.$date.tar
+        rm -f $user.$backup_new_date.tar
     fi
 }
 
@@ -722,7 +723,7 @@ sftp_backup() {
     fi
 
     # Debug info
-    echo -e "$(date "+%F %T") Remote: sftp://$HOST/$BPATH/$user.$date.tar" |\
+    echo -e "$(date "+%F %T") Remote: sftp://$HOST/$BPATH/$user.$backup_new_date.tar" |\
         tee -a $BACKUP/$user.log
 
     # Checking network connection and write permissions
@@ -768,24 +769,24 @@ sftp_backup() {
     fi
 
     # Uploading backup archive
-    echo "$(date "+%F %T") Uploading $user.$date.tar"|tee -a $BACKUP/$user.log
+    echo "$(date "+%F %T") Uploading $user.$backup_new_date.tar"|tee -a $BACKUP/$user.log
     if [ "$localbackup" = 'yes' ]; then
         cd $BACKUP
         if [ -z $BPATH ]; then
-            sftpc "put $user.$date.tar" "chmod 0600 $user.$date.tar" > /dev/null 2>&1
+            sftpc "put $user.$backup_new_date.tar" "chmod 0600 $user.$backup_new_date.tar" > /dev/null 2>&1
         else
-            sftpc "cd $BPATH" "put $user.$date.tar" "chmod 0600 $user.$date.tar" > /dev/null 2>&1
+            sftpc "cd $BPATH" "put $user.$backup_new_date.tar" "chmod 0600 $user.$backup_new_date.tar" > /dev/null 2>&1
         fi
     else
         cd $tmpdir
-        tar -cf $BACKUP/$user.$date.tar .
+        tar -cf $BACKUP/$user.$backup_new_date.tar .
         cd $BACKUP/
         if [ -z $BPATH ]; then
-            sftpc "put $user.$date.tar" "chmod 0600 $user.$date.tar" > /dev/null 2>&1
+            sftpc "put $user.$backup_new_date.tar" "chmod 0600 $user.$backup_new_date.tar" > /dev/null 2>&1
         else
-            sftpc "cd $BPATH" "put $user.$date.tar" "chmod 0600 $user.$date.tar" > /dev/null 2>&1
+            sftpc "cd $BPATH" "put $user.$backup_new_date.tar" "chmod 0600 $user.$backup_new_date.tar" > /dev/null 2>&1
         fi
-        rm -f $user.$date.tar
+        rm -f $user.$backup_new_date.tar
     fi
 }
 
@@ -797,7 +798,7 @@ google_backup() {
     export BOTO_CONFIG="$VESTA/conf/.google.backup.boto"
 
     # Debug info
-    echo -e "$(date "+%F %T") Remote: gs://$BUCKET/$BPATH/$user.$date.tar"
+    echo -e "$(date "+%F %T") Remote: gs://$BUCKET/$BPATH/$user.$backup_new_date.tar"
 
     # Checking retention
     backup_list=$(${gsutil} ls gs://$BUCKET/$BPATH/$user.* 2>/dev/null)
@@ -811,19 +812,19 @@ google_backup() {
     fi
 
     # Uploading backup archive
-    echo -e "$(date "+%F %T") Uploading $user.$date.tar ..."
+    echo -e "$(date "+%F %T") Uploading $user.$backup_new_date.tar ..."
     if [ "$localbackup" = 'yes' ]; then
         cd $BACKUP
-        ${gsutil} cp $user.$date.tar gs://$BUCKET/$BPATH/ > /dev/null 2>&1
+        ${gsutil} cp $user.$backup_new_date.tar gs://$BUCKET/$BPATH/ > /dev/null 2>&1
     else
         cd $tmpdir
-        tar -cf $BACKUP/$user.$date.tar .
+        tar -cf $BACKUP/$user.$backup_new_date.tar .
         cd $BACKUP/
-        ${gsutil} cp $user.$date.tar gs://$BUCKET/$BPATH/ > /dev/null 2>&1
+        ${gsutil} cp $user.$backup_new_date.tar gs://$BUCKET/$BPATH/ > /dev/null 2>&1
         rc=$?
-        rm -f $user.$date.tar
+        rm -f $user.$backup_new_date.tar
         if [ "$rc" -ne 0 ]; then
-            check_result "$E_CONNECT" "gsutil failed to upload $user.$date.tar"
+            check_result "$E_CONNECT" "gsutil failed to upload $user.$backup_new_date.tar"
         fi
     fi
 }
@@ -866,10 +867,10 @@ echo "$(date "+%F %T") Runtime: $run_time $min" |tee -a $BACKUP/$user.log
 
 # Removing duplicate
 touch $USER_DATA/backup.conf
-sed -i "/$user.$date.tar/d" $USER_DATA/backup.conf
+sed -i "/$user.$backup_new_date.tar/d" $USER_DATA/backup.conf
 
 # Registering new backup
-backup_str="BACKUP='$user.$date.tar'"
+backup_str="BACKUP='$user.$backup_new_date.tar'"
 backup_str="$backup_str TYPE='$BACKUP_SYSTEM' SIZE='$size'"
 backup_str="$backup_str WEB='${web_list// /,}'"
 backup_str="$backup_str DNS='${dns_list// /,}'"

--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -38,8 +38,15 @@ source $VESTA/conf/vesta.conf
 
 # Check backup ownership function
 is_backup_available() {
-    if ! [[ $2 =~ ^$1.[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].tar$ ]]; then
-         check_result $E_FORBIDEN "permission denied"
+    passed=false
+    if [[ $2 =~ ^$1.[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]-[0-9][0-9]-[0-9][0-9].tar$ ]]; then
+        passed=true
+    elif [[ $2 =~ ^$1.[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].tar$ ]]; then
+        passed=true
+    fi
+    
+    if [ $passed = false ]; then
+        check_result $E_FORBIDEN "permission denied"
     fi
 }
 


### PR DESCRIPTION
* Backup filename changed

Changed the backup filename for running more backup each day - for example every 4 hours

* Restore user fix with new backup date

* Check if the backup name has an old notation

* Fix backup permission check

* fixed regex

* fix